### PR TITLE
Autocompletion for filter text fields and text areas

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="BooleanMethodIsAlwaysInverted" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UNCHECKED_WARNING" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/src/main/antlr4/link/biosmarcel/baka/FilterLexer.g4
+++ b/src/main/antlr4/link/biosmarcel/baka/FilterLexer.g4
@@ -4,7 +4,7 @@ options {
     caseInsensitive = true;
 }
 
-HAS:                       ('contains'|'has');
+HAS:                       'has';
 AND:                       'and';
 OR:                        'or';
 OPEN_PAR:                  '(';

--- a/src/main/antlr4/link/biosmarcel/baka/FilterLexer.g4
+++ b/src/main/antlr4/link/biosmarcel/baka/FilterLexer.g4
@@ -18,5 +18,5 @@ NOT_EQ:                    '!=';
 STRING:                    ["].*?["];
 BOOLEAN:                   ('true'|'false');
 NUMBER:                    [,.0-9]+;
-WORD:                      ~[ \u000B\t\r\n"]+;
+WORD:                      ~[() \u000B\t\r\n"]+;
 SPACES:                    [ \u000B\t\r\n] -> channel(HIDDEN);

--- a/src/main/antlr4/link/biosmarcel/baka/FilterParser.g4
+++ b/src/main/antlr4/link/biosmarcel/baka/FilterParser.g4
@@ -6,8 +6,8 @@ options {
 
 query:                     expression? EOF;
 expression:                field operator=(LT | LT_EQ | GT | GT_EQ | EQ | NOT_EQ | HAS) value     #comparatorExpression
-                           | expression operator=(AND | OR) expression                            #binaryExpression
                            | OPEN_PAR expression CLOSE_PAR                                        #groupedExpression
+                           | expression operator=(AND | OR) expression                            #binaryExpression
                            ;
 
 field:                     WORD;

--- a/src/main/java/link/biosmarcel/baka/data/ClassificationRule.java
+++ b/src/main/java/link/biosmarcel/baka/data/ClassificationRule.java
@@ -18,7 +18,9 @@ public class ClassificationRule {
     public boolean test(final Payment payment) {
         if (compiled == null) {
             compiled = new PaymentFilter();
-            if (!compiled.setQuery(query)) {
+            try {
+                compiled.setQuery(query);
+            } catch (final RuntimeException exception) {
                 return false;
             }
         }

--- a/src/main/java/link/biosmarcel/baka/data/ClassificationRule.java
+++ b/src/main/java/link/biosmarcel/baka/data/ClassificationRule.java
@@ -3,6 +3,8 @@ package link.biosmarcel.baka.data;
 import link.biosmarcel.baka.view.PaymentFilter;
 import org.jspecify.annotations.Nullable;
 
+import java.util.function.Predicate;
+
 public class ClassificationRule {
     public String name = "";
     public String tag = "";
@@ -13,15 +15,17 @@ public class ClassificationRule {
         this.query = query;
     }
 
-    private transient @Nullable PaymentFilter compiled = null;
+    private transient @Nullable Predicate<Payment> compiled = null;
 
     public boolean test(final Payment payment) {
         if (compiled == null) {
-            compiled = new PaymentFilter();
+            final var compiled = new PaymentFilter();
             try {
                 compiled.setQuery(query);
+                this.compiled = compiled;
             } catch (final RuntimeException exception) {
-                return false;
+                // FIXME This should give user feedback
+                this.compiled = _ -> false;
             }
         }
 

--- a/src/main/java/link/biosmarcel/baka/filter/BinaryExpressionType.java
+++ b/src/main/java/link/biosmarcel/baka/filter/BinaryExpressionType.java
@@ -1,8 +1,8 @@
 package link.biosmarcel.baka.filter;
 
 public enum BinaryExpressionType {
-    AND("AND"),
-    OR("OR"),
+    AND("and"),
+    OR("or"),
     ;
 
     public final String text;

--- a/src/main/java/link/biosmarcel/baka/filter/BinaryExpressionType.java
+++ b/src/main/java/link/biosmarcel/baka/filter/BinaryExpressionType.java
@@ -1,7 +1,13 @@
 package link.biosmarcel.baka.filter;
 
 public enum BinaryExpressionType {
-    AND,
-    OR,
+    AND("AND"),
+    OR("OR"),
     ;
+
+    public final String text;
+
+    BinaryExpressionType(String text) {
+        this.text = text;
+    }
 }

--- a/src/main/java/link/biosmarcel/baka/filter/Filter.java
+++ b/src/main/java/link/biosmarcel/baka/filter/Filter.java
@@ -100,7 +100,7 @@ public class Filter<FilterTarget> implements Predicate<FilterTarget> {
                 final String textLowered = text.toLowerCase();
                 return operators
                         .stream()
-                        .filter(operator -> operator.text.startsWith(textLowered))
+                        .filter(operator -> operator.text.toLowerCase().startsWith(textLowered))
                         .map(op -> op.text)
                         .sorted()
                         .toList();
@@ -109,13 +109,15 @@ public class Filter<FilterTarget> implements Predicate<FilterTarget> {
             @Override
             public void enterComparatorExpression(final FilterParser.ComparatorExpressionContext ctx) {
                 final var targetContext = contextToExpression.get(ctx.parent);
-                final var operatorToExtractor = fieldToOperatorToExtractor.get(ctx.field().getText());
+                final var field = ctx.field().getText();
+                final var lowercaseField = field.toLowerCase();
+                final var operatorToExtractor = fieldToOperatorToExtractor.get(lowercaseField);
                 if (operatorToExtractor == null) {
                     throw new IncompleteQueryException(false,
                             ctx.field().getText(),
                             fieldToOperatorToExtractor.keySet()
                                     .stream()
-                                    .filter(key -> key.startsWith(ctx.field().getText()))
+                                    .filter(key -> key.startsWith(lowercaseField))
                                     .toList());
                 }
 

--- a/src/main/java/link/biosmarcel/baka/filter/FilterAutocompleteGenerator.java
+++ b/src/main/java/link/biosmarcel/baka/filter/FilterAutocompleteGenerator.java
@@ -1,17 +1,13 @@
-package link.biosmarcel.baka.view;
-
-import link.biosmarcel.baka.filter.BinaryExpressionType;
-import link.biosmarcel.baka.filter.Filter;
-import link.biosmarcel.baka.filter.IncompleteQueryException;
+package link.biosmarcel.baka.filter;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class AutocompleteGenerator {
+public class FilterAutocompleteGenerator {
     private final Filter<?> filter;
 
-    public AutocompleteGenerator(final Filter<?> filter) {
+    public FilterAutocompleteGenerator(final Filter<?> filter) {
         this.filter = filter;
     }
 

--- a/src/main/java/link/biosmarcel/baka/filter/IncompleteQueryException.java
+++ b/src/main/java/link/biosmarcel/baka/filter/IncompleteQueryException.java
@@ -1,0 +1,17 @@
+package link.biosmarcel.baka.filter;
+
+import java.util.List;
+
+public class IncompleteQueryException extends RuntimeException {
+    public final boolean empty;
+    public final String token;
+    public final List<String> options;
+
+    public IncompleteQueryException(final boolean empty,
+                                    final String token,
+                                    final List<String> options) {
+        this.empty = empty;
+        this.token = token;
+        this.options = options;
+    }
+}

--- a/src/main/java/link/biosmarcel/baka/filter/Operator.java
+++ b/src/main/java/link/biosmarcel/baka/filter/Operator.java
@@ -1,11 +1,29 @@
 package link.biosmarcel.baka.filter;
 
+import org.jspecify.annotations.Nullable;
+
 public enum Operator {
-    EQ,
-    NOT_EQ,
-    HAS,
-    LT,
-    LT_EQ,
-    GT,
-    GT_EQ,
+    EQ("="),
+    NOT_EQ("!="),
+    HAS("has"),
+    LT("<"),
+    LT_EQ("<="),
+    GT(">"),
+    GT_EQ(">=");
+
+    public final String text;
+
+    Operator(final String text) {
+        this.text = text;
+    }
+
+    public static @Nullable Operator match(final String text) {
+        for (final var operator : Operator.values()) {
+            if (operator.text.equalsIgnoreCase(text)) {
+                return operator;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteField.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteField.java
@@ -1,0 +1,28 @@
+package link.biosmarcel.baka.view;
+
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.control.skin.TextFieldSkin;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class AutocompleteField extends AutocompleteInput {
+    public AutocompleteField(Function<String, List<String>> autocompleteGenerator) {
+        super(autocompleteGenerator);
+    }
+
+    @Override
+    void positionPopup() {
+        final var textFieldBounds = input.getBoundsInParent();
+        completionList.setTranslateY(textFieldBounds.getMaxY());
+
+        final var caretBounds = ((TextFieldSkin) input.getSkin()).getCharacterBounds(input.getCaretPosition());
+        completionList.setTranslateX(textFieldBounds.getMinX() + caretBounds.getMinX());
+    }
+
+    @Override
+    TextInputControl createInput() {
+        return new TextField();
+    }
+}

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteField.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteField.java
@@ -1,5 +1,6 @@
 package link.biosmarcel.baka.view;
 
+import javafx.geometry.Point2D;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.control.skin.TextFieldSkin;
@@ -13,12 +14,10 @@ public class AutocompleteField extends AutocompleteInput {
     }
 
     @Override
-    void positionPopup() {
+    Point2D computePopupLocation() {
         final var textFieldBounds = input.getBoundsInParent();
-        completionList.setTranslateY(textFieldBounds.getMaxY());
-
         final var caretBounds = ((TextFieldSkin) input.getSkin()).getCharacterBounds(input.getCaretPosition());
-        completionList.setTranslateX(textFieldBounds.getMinX() + caretBounds.getMinX());
+        return new Point2D(textFieldBounds.getMinX() + caretBounds.getMinX(), textFieldBounds.getMaxY());
     }
 
     @Override

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteField.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteField.java
@@ -9,8 +9,10 @@ import java.util.List;
 import java.util.function.Function;
 
 public class AutocompleteField extends AutocompleteInput {
-    public AutocompleteField(Function<String, List<String>> autocompleteGenerator) {
-        super(autocompleteGenerator);
+    public AutocompleteField(
+            final char[] tokenSeparators,
+            final Function<String, List<String>> autocompleteGenerator) {
+        super(tokenSeparators, autocompleteGenerator);
     }
 
     @Override

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteGenerator.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteGenerator.java
@@ -1,0 +1,39 @@
+package link.biosmarcel.baka.view;
+
+import link.biosmarcel.baka.filter.BinaryExpressionType;
+import link.biosmarcel.baka.filter.Filter;
+import link.biosmarcel.baka.filter.IncompleteQueryException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AutocompleteGenerator {
+    private final Filter<?> filter;
+
+    public AutocompleteGenerator(final Filter<?> filter) {
+        this.filter = filter;
+    }
+
+    public List<String> generate(final String value) {
+        try {
+            filter.setQuery(value);
+            if (value.endsWith(")") || value.endsWith(" ") || value.endsWith("\n")) {
+                // If the query is valid so far, we can always attach another via binary operators.
+                return Arrays.stream(BinaryExpressionType.values()).map(bo -> bo.text).toList();
+            }
+            return Collections.EMPTY_LIST;
+        } catch (final IncompleteQueryException exception) {
+            if ((value.endsWith("(") && exception.token.isBlank()) ||
+                    (value.endsWith(exception.token) &&
+                            (!exception.token.isEmpty() || value.isEmpty() || !value.stripTrailing().equalsIgnoreCase(value)))
+            ) {
+                return exception.options;
+            }
+            return Collections.EMPTY_LIST;
+        } catch (final RuntimeException exception) {
+            System.out.println(exception.getMessage());
+            return Collections.EMPTY_LIST;
+        }
+    }
+}

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteHelper.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteHelper.java
@@ -1,0 +1,47 @@
+package link.biosmarcel.baka.view;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.control.Tooltip;
+import javafx.stage.PopupWindow;
+
+public final class AutocompleteHelper {
+    private AutocompleteHelper() {
+    }
+
+    public static void installErrorToolTip(final AutocompleteInput input,
+                                           final StringProperty error,
+                                           final BooleanProperty fatal) {
+        Tooltip errorTooltip = new Tooltip("");
+        errorTooltip.textProperty().bind(error);
+        errorTooltip.setAnchorLocation(PopupWindow.AnchorLocation.CONTENT_TOP_RIGHT);
+        input.focusedProperty().addListener((_, _, newValue) -> {
+            if (!newValue) {
+                errorTooltip.hide();
+                return;
+            }
+
+            if (!errorTooltip.getText().isEmpty()) {
+                final var bounds = input.getNode().localToScreen(input.getNode().getLayoutBounds());
+                errorTooltip.show(input.getNode(), bounds.getMinX(), bounds.getMinY());
+            }
+        });
+
+        error.addListener((_, _, newText) -> {
+            if (newText.isEmpty()) {
+                errorTooltip.hide();
+            } else {
+                final var bounds = input.getNode().localToScreen(input.getNode().getLayoutBounds());
+                errorTooltip.show(input.getNode(), bounds.getMinX(), bounds.getMinY());
+            }
+        });
+
+        fatal.addListener((_, _, newValue) -> {
+            if (newValue) {
+                input.indicateError();
+            } else {
+                input.clearError();
+            }
+        });
+    }
+}

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
@@ -60,8 +60,13 @@ public abstract class AutocompleteInput {
         });
 
         input.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
-            // FIXME Ctrl+Home/End
-            if (event.getCode() == KeyCode.UP) {
+            if (event.getCode() == KeyCode.HOME && event.isControlDown()) {
+                event.consume();
+                completionList.getSelectionModel().select(0);
+            } else if (event.getCode() == KeyCode.END && event.isControlDown()) {
+                event.consume();
+                completionList.getSelectionModel().select(completionList.getItems().size() - 1);
+            } else if (event.getCode() == KeyCode.UP) {
                 event.consume();
                 if (completionList.getSelectionModel().getSelectedIndex() != 0) {
                     completionList.getSelectionModel().select(completionList.getSelectionModel().getSelectedIndex() + -1);

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
@@ -22,13 +22,17 @@ public abstract class AutocompleteInput {
     private final Pane pane;
     private final ListView<String> completionList;
     private final Function<String, List<String>> autocompleteGenerator;
+    private final char[] tokenSeparators;
 
     protected final TextInputControl input;
 
-    public AutocompleteInput(final Function<String, List<String>> autocompleteGenerator) {
+    public AutocompleteInput(
+            final char[] tokenSeparators,
+            final Function<String, List<String>> autocompleteGenerator) {
         pane = new Pane();
         input = createInput();
         completionList = new ListView<>();
+        this.tokenSeparators = tokenSeparators;
         this.autocompleteGenerator = autocompleteGenerator;
 
         // This is what is the Z-Index on the web. It allows us to render our popup above everything else.
@@ -108,8 +112,6 @@ public abstract class AutocompleteInput {
         return input.isFocused() && !input.isDisabled();
     }
 
-    private static final char[] autocompleteAfterChars = new char[]{')', '(', ' ', '\n'};
-
     private void complete() {
         final String selectedItem = completionList.getSelectionModel().getSelectedItem();
         // selection is always nullable
@@ -121,7 +123,7 @@ public abstract class AutocompleteInput {
         final var textBeforeCaret = input.getText().substring(0, input.getCaretPosition());
 
         int autocompleteTo = -1;
-        for (final char c : autocompleteAfterChars) {
+        for (final char c : tokenSeparators) {
             autocompleteTo = Integer.max(textBeforeCaret.lastIndexOf(c), autocompleteTo);
         }
 

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
@@ -1,6 +1,7 @@
 package link.biosmarcel.baka.view;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
@@ -11,6 +12,7 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 import org.jspecify.annotations.Nullable;
 
@@ -212,6 +214,20 @@ public abstract class AutocompleteInput {
         return input.disableProperty();
     }
 
+    public ReadOnlyBooleanProperty focusedProperty() {
+        return input.focusedProperty();
+    }
+
+    public void clearError() {
+        input.getStyleClass().remove("text-field-error");
+    }
+
+    public void indicateError() {
+        // Prevent adding class twice.
+        clearError();
+        input.getStyleClass().add("text-field-error");
+    }
+
     private void toFront(Node node) {
         node.setViewOrder(-1);
         if (node.getParent() != null) {
@@ -219,7 +235,7 @@ public abstract class AutocompleteInput {
         }
     }
 
-    public Node getNode() {
+    public Region getNode() {
         return pane;
     }
 

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
@@ -1,0 +1,178 @@
+package link.biosmarcel.baka.view;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.Node;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+public abstract class AutocompleteInput {
+    private final Pane pane;
+    public final TextInputControl input;
+    protected final ListView<String> completionList;
+
+    public AutocompleteInput(Function<String, List<String>> autocompleteGenerator) {
+        pane = new Pane();
+        input = createInput();
+        completionList = new ListView<>();
+
+        // This is what is the Z-Index on the web. It allows us to render our popup above everything else.
+        pane.getChildren().add(input);
+        pane.getChildren().add(completionList);
+        pane.maxHeightProperty().bind(input.heightProperty());
+        pane.maxWidthProperty().bind(input.widthProperty());
+
+        completionList.setFixedCellSize(35.0);
+        completionList.setMaxHeight(8 * completionList.getFixedCellSize());
+        completionList.setBackground(Background.fill(Color.WHITE));
+        completionList.setFocusTraversable(false);
+        completionList.setVisible(false);
+        completionList.setCellFactory(_ -> {
+            final ListCell<@Nullable String> cell = new ListCell<>() {
+                @Override
+                protected void updateItem(final @Nullable String item, boolean empty) {
+                    super.updateItem(item, empty);
+
+                    if (!empty && item != null) {
+                        setText(item);
+                    } else {
+                        setText("");
+                    }
+                }
+            };
+            cell.setOnMouseClicked(_ -> complete());
+            return cell;
+        });
+
+        input.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+            // FIXME Ctrl+Home/End
+            if (event.getCode() == KeyCode.UP) {
+                event.consume();
+                if (completionList.getSelectionModel().getSelectedIndex() != 0) {
+                    completionList.getSelectionModel().select(completionList.getSelectionModel().getSelectedIndex() + -1);
+                }
+            } else if (event.getCode() == KeyCode.DOWN) {
+                event.consume();
+                completionList.getSelectionModel().select(completionList.getSelectionModel().getSelectedIndex() - -1);
+            } else if (event.getCode() == KeyCode.ENTER) {
+                if (event.isShiftDown()) {
+                    input.insertText(input.getCaretPosition(), "\n");
+                } else if (completionList.isVisible()) {
+                    event.consume();
+                    complete();
+                }
+            }
+        });
+
+        input.focusedProperty().addListener((_, _, _) -> {
+            if (!canShowPopup()) {
+                hidePopup();
+                return;
+            }
+
+            updatePopupItems(autocompleteGenerator.apply(input.getText().substring(0, input.getCaretPosition())));
+            refreshPopup();
+        });
+
+        input.caretPositionProperty().addListener((_, _, newValue) -> {
+            if (!canShowPopup()) {
+                return;
+            }
+
+            updatePopupItems(autocompleteGenerator.apply(input.getText().substring(0, newValue.intValue())));
+            refreshPopup();
+        });
+    }
+
+    private boolean canShowPopup() {
+        return input.isFocused() && !input.isDisabled();
+    }
+
+    private void complete() {
+        final String selectedItem = completionList.getSelectionModel().getSelectedItem();
+        // selection is always nullable
+        //noinspection ConstantValue
+        if (selectedItem != null) {
+            final var textBeforeCaret = input.getText().substring(0, input.getCaretPosition());
+
+            // FIXME Properly preserve newlines?
+            // FIXME Autocomplete over selection?
+            var lastSpace = textBeforeCaret.lastIndexOf(' ');
+            if (lastSpace == 1) {
+                lastSpace = textBeforeCaret.lastIndexOf('\n');
+            }
+            final var preCompletionText = textBeforeCaret.substring(0, lastSpace + 1);
+
+            // FIXME Use insert?
+            input.setText(preCompletionText + selectedItem + " " + input.getText().substring(input.getCaretPosition()));
+            // We add a space at the end, so we can start writing / completing the next token type right away.
+            input.positionCaret(preCompletionText.length() + selectedItem.length() + 1);
+        }
+    }
+
+    private void updatePopupItems(final Collection<String> newItems) {
+        completionList.getItems().removeIf(item -> !newItems.contains(item));
+        for (final String newItem : newItems) {
+            if (!completionList.getItems().contains(newItem)) {
+                completionList.getItems().add(newItem);
+            }
+        }
+        completionList.getItems().sort(String::compareTo);
+    }
+
+    public void hidePopup() {
+        completionList.setVisible(false);
+    }
+
+    public void refreshPopup() {
+        if (completionList.getItems().isEmpty()) {
+            hidePopup();
+            return;
+        }
+
+        // +2 to prevent an unnecessary scrollbar
+        if (completionList.getSelectionModel().getSelectedIndex() == -1) {
+            completionList.getSelectionModel().select(0);
+        }
+
+        completionList.setPrefHeight(completionList.getItems().size() * completionList.getFixedCellSize() + 2);
+        positionPopup();
+        toFront(completionList);
+
+        completionList.setVisible(true);
+    }
+
+    public StringProperty textProperty() {
+        return input.textProperty();
+    }
+
+    public BooleanProperty disableProperty() {
+        return input.disableProperty();
+    }
+
+    private void toFront(Node node) {
+        node.setViewOrder(-1);
+        if (node.getParent() != null) {
+            toFront(node.getParent());
+        }
+    }
+
+    public Node getNode() {
+        return pane;
+    }
+
+    abstract void positionPopup();
+
+    abstract TextInputControl createInput();
+}

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
@@ -108,9 +108,6 @@ public abstract class AutocompleteInput {
         if (selectedItem != null) {
             final var textBeforeCaret = input.getText().substring(0, input.getCaretPosition());
 
-            // FIXME Properly preserve newlines?
-            // FIXME Autocomplete over selection?
-
             int autocompleteTo = -1;
             for (final char c : autocompleteAfterChars) {
                 autocompleteTo = Integer.max(textBeforeCaret.lastIndexOf(c), autocompleteTo);

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteInput.java
@@ -69,11 +69,11 @@ public abstract class AutocompleteInput {
             } else if (event.getCode() == KeyCode.UP) {
                 event.consume();
                 if (completionList.getSelectionModel().getSelectedIndex() != 0) {
-                    completionList.getSelectionModel().select(completionList.getSelectionModel().getSelectedIndex() + -1);
+                    completionList.getSelectionModel().select(completionList.getSelectionModel().getSelectedIndex() - 1);
                 }
             } else if (event.getCode() == KeyCode.DOWN) {
                 event.consume();
-                completionList.getSelectionModel().select(completionList.getSelectionModel().getSelectedIndex() - -1);
+                completionList.getSelectionModel().select(completionList.getSelectionModel().getSelectedIndex() + 1);
             } else if (event.getCode() == KeyCode.ENTER) {
                 if (event.isShiftDown()) {
                     input.insertText(input.getCaretPosition(), "\n");

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteTextArea.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteTextArea.java
@@ -9,8 +9,11 @@ import java.util.List;
 import java.util.function.Function;
 
 public class AutocompleteTextArea extends AutocompleteInput {
-    public AutocompleteTextArea(Function<String, List<String>> autocompleteGenerator) {
-        super(autocompleteGenerator);
+    public AutocompleteTextArea(
+            final char[] tokenSeparators,
+            final Function<String, List<String>> autocompleteGenerator
+    ) {
+        super(tokenSeparators, autocompleteGenerator);
     }
 
     @Override

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteTextArea.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteTextArea.java
@@ -1,0 +1,29 @@
+package link.biosmarcel.baka.view;
+
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.control.skin.TextAreaSkin;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class AutocompleteTextArea extends AutocompleteInput {
+    public AutocompleteTextArea(Function<String, List<String>> autocompleteGenerator) {
+        super(autocompleteGenerator);
+    }
+
+    @Override
+    void positionPopup() {
+        final var textFieldBounds = input.getBoundsInParent();
+        // Required, as the bounds will be outdated otherwise.
+        input.layout();
+        final var bounds = ((TextAreaSkin) input.getSkin()).getCaretBounds();
+        completionList.setTranslateX(textFieldBounds.getMinX() + bounds.getMinX());
+        completionList.setTranslateY(textFieldBounds.getMinY() + bounds.getMaxY());
+    }
+
+    @Override
+    TextInputControl createInput() {
+        return new TextArea();
+    }
+}

--- a/src/main/java/link/biosmarcel/baka/view/AutocompleteTextArea.java
+++ b/src/main/java/link/biosmarcel/baka/view/AutocompleteTextArea.java
@@ -1,5 +1,6 @@
 package link.biosmarcel.baka.view;
 
+import javafx.geometry.Point2D;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.control.skin.TextAreaSkin;
@@ -13,13 +14,13 @@ public class AutocompleteTextArea extends AutocompleteInput {
     }
 
     @Override
-    void positionPopup() {
-        final var textFieldBounds = input.getBoundsInParent();
+    Point2D computePopupLocation() {
         // Required, as the bounds will be outdated otherwise.
         input.layout();
+
+        final var textFieldBounds = input.getBoundsInParent();
         final var bounds = ((TextAreaSkin) input.getSkin()).getCaretBounds();
-        completionList.setTranslateX(textFieldBounds.getMinX() + bounds.getMinX());
-        completionList.setTranslateY(textFieldBounds.getMinY() + bounds.getMaxY());
+        return new Point2D(textFieldBounds.getMinX() + bounds.getMinX(), textFieldBounds.getMinY() + bounds.getMaxY());
     }
 
     @Override

--- a/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
@@ -47,7 +47,10 @@ public class ClassificationsView extends BakaTab {
         selectedRuleProperty = listView.getSelectionModel().selectedItemProperty();
         nameField = new TextField();
         tagField = new TextField();
-        queryField = new AutocompleteTextArea(new FilterAutocompleteGenerator(new PaymentFilter())::generate);
+        queryField = new AutocompleteTextArea(
+                new char[]{')', '(', ' ', '\n'},
+                new FilterAutocompleteGenerator(new PaymentFilter())::generate
+        );
 
         final BooleanBinding disableInputs = Bindings.createBooleanBinding(() -> selectedRuleProperty.getValue() == null, selectedRuleProperty);
         selectedRuleProperty.addListener((_, oldValue, newValue) -> {

--- a/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
@@ -10,6 +10,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import link.biosmarcel.baka.ApplicationState;
 import link.biosmarcel.baka.data.ClassificationRule;
+import link.biosmarcel.baka.filter.FilterAutocompleteGenerator;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ public class ClassificationsView extends BakaTab {
         selectedRuleProperty = listView.getSelectionModel().selectedItemProperty();
         nameField = new TextField();
         tagField = new TextField();
-        queryField = new AutocompleteTextArea(new AutocompleteGenerator(new PaymentFilter())::generate);
+        queryField = new AutocompleteTextArea(new FilterAutocompleteGenerator(new PaymentFilter())::generate);
 
         final BooleanBinding disableInputs = Bindings.createBooleanBinding(() -> selectedRuleProperty.getValue() == null, selectedRuleProperty);
         selectedRuleProperty.addListener((_, oldValue, newValue) -> {

--- a/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
@@ -10,17 +10,19 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import link.biosmarcel.baka.ApplicationState;
 import link.biosmarcel.baka.data.ClassificationRule;
+import link.biosmarcel.baka.filter.IncompleteQueryException;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class ClassificationsView extends BakaTab {
     private final ListView<ClassificationRuleFX> listView;
     private final TextField nameField;
     private final TextField tagField;
-    private final TextArea queryField;
+    private final AutocompleteTextArea queryField;
     private final ReadOnlyObjectProperty<@Nullable ClassificationRuleFX> selectedRuleProperty;
 
 
@@ -46,7 +48,23 @@ public class ClassificationsView extends BakaTab {
         selectedRuleProperty = listView.getSelectionModel().selectedItemProperty();
         nameField = new TextField();
         tagField = new TextField();
-        queryField = new TextArea();
+        final var autocompleteFilter = new PaymentFilter();
+        queryField = new AutocompleteTextArea((value) -> {
+            try {
+                autocompleteFilter.setQuery(value);
+                return Collections.EMPTY_LIST;
+            } catch (final IncompleteQueryException exception) {
+                if (value.endsWith(exception.token) &&
+                        (!exception.token.isEmpty() || value.isEmpty() || !value.stripTrailing().equalsIgnoreCase(value))
+                ) {
+                    return exception.options;
+                }
+                return Collections.EMPTY_LIST;
+            } catch (final RuntimeException exception) {
+                System.out.println(exception.getMessage());
+                return Collections.EMPTY_LIST;
+            }
+        });
 
         final BooleanBinding disableInputs = Bindings.createBooleanBinding(() -> selectedRuleProperty.getValue() == null, selectedRuleProperty);
         selectedRuleProperty.addListener((_, oldValue, newValue) -> {
@@ -59,7 +77,7 @@ public class ClassificationsView extends BakaTab {
 
                 nameField.setText("");
                 tagField.setText("");
-                queryField.setText("");
+                queryField.textProperty().set("");
             }
 
             if (newValue != null) {
@@ -78,7 +96,7 @@ public class ClassificationsView extends BakaTab {
         details.add(new Label("Tag"), 0, 1);
         details.add(tagField, 1, 1);
         details.add(new Label("Query"), 0, 2);
-        details.add(queryField, 1, 2);
+        details.add(queryField.getNode(), 1, 2);
 
         final var newButton = new Button("New");
         newButton.setOnAction(_ -> {

--- a/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/ClassificationsView.java
@@ -10,12 +10,10 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import link.biosmarcel.baka.ApplicationState;
 import link.biosmarcel.baka.data.ClassificationRule;
-import link.biosmarcel.baka.filter.IncompleteQueryException;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 public class ClassificationsView extends BakaTab {
@@ -48,23 +46,7 @@ public class ClassificationsView extends BakaTab {
         selectedRuleProperty = listView.getSelectionModel().selectedItemProperty();
         nameField = new TextField();
         tagField = new TextField();
-        final var autocompleteFilter = new PaymentFilter();
-        queryField = new AutocompleteTextArea((value) -> {
-            try {
-                autocompleteFilter.setQuery(value);
-                return Collections.EMPTY_LIST;
-            } catch (final IncompleteQueryException exception) {
-                if (value.endsWith(exception.token) &&
-                        (!exception.token.isEmpty() || value.isEmpty() || !value.stripTrailing().equalsIgnoreCase(value))
-                ) {
-                    return exception.options;
-                }
-                return Collections.EMPTY_LIST;
-            } catch (final RuntimeException exception) {
-                System.out.println(exception.getMessage());
-                return Collections.EMPTY_LIST;
-            }
-        });
+        queryField = new AutocompleteTextArea(new AutocompleteGenerator(new PaymentFilter())::generate);
 
         final BooleanBinding disableInputs = Bindings.createBooleanBinding(() -> selectedRuleProperty.getValue() == null, selectedRuleProperty);
         selectedRuleProperty.addListener((_, oldValue, newValue) -> {

--- a/src/main/java/link/biosmarcel/baka/view/PaymentFilter.java
+++ b/src/main/java/link/biosmarcel/baka/view/PaymentFilter.java
@@ -4,6 +4,7 @@ import link.biosmarcel.baka.data.Payment;
 import link.biosmarcel.baka.filter.Filter;
 import link.biosmarcel.baka.filter.Operator;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -14,6 +15,17 @@ public class PaymentFilter extends Filter<Payment> {
     private static final DateTimeFormatter DATE_FORMAT = new DateTimeFormatterBuilder().appendPattern("d.M.[uuuu][uu]").toFormatter();
 
     {
+        // FIXME Optimised containsLowerCased
+
+        register("account", Operator.EQ, (payment, value) -> payment.account.name != null && payment.account.name.equalsIgnoreCase(value), String::toLowerCase);
+        register("account", Operator.NOT_EQ, (payment, value) -> payment.account.name == null || !payment.account.name.equalsIgnoreCase(value), String::toLowerCase);
+        register("account", Operator.HAS, (payment, value) -> payment.account.name != null && !payment.account.name.toLowerCase().contains(value), String::toLowerCase);
+
+        register("amount", Operator.LT, (payment, value) -> payment.amount.compareTo(value) < 0, BigDecimal::new);
+        register("amount", Operator.GT, (payment, value) -> payment.amount.compareTo(value) > 0, BigDecimal::new);
+        register("amount", Operator.LT_EQ, (payment, value) -> payment.amount.compareTo(value) <= 0, BigDecimal::new);
+        register("amount", Operator.GT_EQ, (payment, value) -> payment.amount.compareTo(value) >= 0, BigDecimal::new);
+
         register("name", Operator.EQ, (payment, value) -> payment.name.equalsIgnoreCase(value), String::toLowerCase);
         register("name", Operator.NOT_EQ, (payment, value) -> !payment.name.equalsIgnoreCase(value), String::toLowerCase);
         register("name", Operator.HAS, (payment, value) -> payment.name.toLowerCase().contains(value), String::toLowerCase);

--- a/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -81,18 +80,7 @@ public class PaymentsView extends BakaTab {
 
         details = new PaymentDetails(state);
 
-        // FIXME Can we make parts reusable?
-        final var autocompleteFilter = new PaymentFilter();
-        final var filterField = new AutocompleteField((value) -> {
-            try {
-                autocompleteFilter.setQuery(value);
-                return Collections.EMPTY_LIST;
-            } catch (final IncompleteQueryException exception) {
-                return exception.options;
-            } catch (final RuntimeException exception) {
-                return Collections.EMPTY_LIST;
-            }
-        });
+        final var filterField = new AutocompleteField(new AutocompleteGenerator(new PaymentFilter())::generate);
         final var filter = new PaymentFilter();
         filterField.textProperty().addListener((_, _, newText) -> {
             try {

--- a/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
@@ -15,6 +15,7 @@ import link.biosmarcel.baka.ApplicationState;
 import link.biosmarcel.baka.data.Account;
 import link.biosmarcel.baka.data.Classification;
 import link.biosmarcel.baka.data.Payment;
+import link.biosmarcel.baka.filter.FilterAutocompleteGenerator;
 import link.biosmarcel.baka.filter.IncompleteQueryException;
 
 import java.io.File;
@@ -80,7 +81,7 @@ public class PaymentsView extends BakaTab {
 
         details = new PaymentDetails(state);
 
-        final var filterField = new AutocompleteField(new AutocompleteGenerator(new PaymentFilter())::generate);
+        final var filterField = new AutocompleteField(new FilterAutocompleteGenerator(new PaymentFilter())::generate);
         final var filter = new PaymentFilter();
         filterField.textProperty().addListener((_, _, newText) -> {
             try {

--- a/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
@@ -1,5 +1,9 @@
 package link.biosmarcel.baka.view;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -86,15 +90,28 @@ public class PaymentsView extends BakaTab {
                 new FilterAutocompleteGenerator(new PaymentFilter())::generate
         );
         final var filter = new PaymentFilter();
+
+        StringProperty filterError = new SimpleStringProperty();
+        BooleanProperty fatalError = new SimpleBooleanProperty();
+        AutocompleteHelper.installErrorToolTip(filterField, filterError, fatalError);
+
         filterField.textProperty().addListener((_, _, newText) -> {
             try {
+                filterError.set("");
+                fatalError.set(false);
                 filter.setQuery(newText);
                 filteredData.setPredicate(paymentFX -> filter.test(paymentFX.payment));
             } catch (final IncompleteQueryException exception) {
                 if (exception.empty) {
                     filteredData.setPredicate(null);
+                } else {
+                    filterError.set("Query is incomplete.");
+                    fatalError.set(false);
                 }
                 // If the query is not empty, but incomplete, it isn't really an issue.
+            } catch (final RuntimeException exception) {
+                filterError.set(exception.getMessage());
+                fatalError.set(true);
             }
         });
 

--- a/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
@@ -81,7 +81,10 @@ public class PaymentsView extends BakaTab {
 
         details = new PaymentDetails(state);
 
-        final var filterField = new AutocompleteField(new FilterAutocompleteGenerator(new PaymentFilter())::generate);
+        final var filterField = new AutocompleteField(
+                new char[]{')', '(', ' ', '\n'},
+                new FilterAutocompleteGenerator(new PaymentFilter())::generate
+        );
         final var filter = new PaymentFilter();
         filterField.textProperty().addListener((_, _, newText) -> {
             try {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -10,5 +10,6 @@ module link.biosmarcel.baka {
     exports link.biosmarcel.baka;
     exports link.biosmarcel.baka.bankimport;
     exports link.biosmarcel.baka.data;
+    exports link.biosmarcel.baka.filter;
     exports link.biosmarcel.baka.view;
 }

--- a/src/main/resources/link/biosmarcel/baka/base.css
+++ b/src/main/resources/link/biosmarcel/baka/base.css
@@ -12,3 +12,7 @@
     -fx-background-radius: 4px;
     -fx-padding: 4px;
 }
+
+.text-field-error {
+    -fx-control-inner-background: rgb(255,160,160);
+}

--- a/src/test/java/link/biosmarcel/baka/view/PaymentFilterTest.java
+++ b/src/test/java/link/biosmarcel/baka/view/PaymentFilterTest.java
@@ -2,6 +2,7 @@ package link.biosmarcel.baka.view;
 
 import link.biosmarcel.baka.data.Account;
 import link.biosmarcel.baka.data.Payment;
+import link.biosmarcel.baka.filter.IncompleteQueryException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,12 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 class PaymentFilterTest {
+    @Test
+    public void test_emptyGroup() {
+        final var filter = new PaymentFilter();
+        Assertions.assertThrows(IncompleteQueryException.class, () -> filter.setQuery("()"));
+    }
+
     @Test
     public void test_BinaryExpression_LowerCase() {
         final var now = LocalDateTime.now();


### PR DESCRIPTION
Todos:

- [x] Preserve newlines when autocompleting
- [x] Offer autocompletion directly after open paranthesis
- [x] Offer autocompletion for binary operators (Could be difficult)
- [x] Simplify usage of api
- [x] Make sure popup doesn't render out of bounds
- [x] Do a lookahead on completion to prevent accidentally recompleting an existing word partially
- [x] Properly handle selection
- [x] Use input.insert where possible instead of setText
- [x] Make completion independent of content type to complete
  > Currently it contains logic specific to the filter language
- [x] Add indicator of whether the query is valid
- [x] ~Fuzzy autocomplete~ Will be a separate issue after the PR

Imperfections I'll accept for now:

* Y out of bounds isn't treated
* Binary operators aren't autocompleted correctly.
  > The completion is a hack implemented outside of the parser. We can only do full completion, not partial completion, due to the fact we don't run into the binaryExpression rule of the parser. I tried changing the parser, but to no success.

A solution to any parsing problems is potentially throwing away antlr and writing a custom parser.