### PR TITLE
Import directories are now stored and restored

### DIFF
--- a/.idea/runConfigurations/Main.xml
+++ b/.idea/runConfigurations/Main.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Main" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="link.biosmarcel.baka.Main" />
+    <module name="baka.main" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="link.biosmarcel.baka.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/main/java/link/biosmarcel/baka/Main.java
+++ b/src/main/java/link/biosmarcel/baka/Main.java
@@ -18,6 +18,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Locale;
 
@@ -84,6 +85,8 @@ public class Main extends Application {
                 //})
                 .setRoot(data)
                 .start();
+
+        data.init();
 
         final ApplicationState state = new ApplicationState(storageManager, storageManager.createEagerStorer(), data);
         final DebugView debugView = new DebugView(state);

--- a/src/main/java/link/biosmarcel/baka/data/ConvenienceState.java
+++ b/src/main/java/link/biosmarcel/baka/data/ConvenienceState.java
@@ -1,0 +1,37 @@
+package link.biosmarcel.baka.data;
+
+import org.jspecify.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Contains all state, that is irrelevant for business logic. These can be things such as file paths, window sizes or
+ * other things that aren't necessary for producing / storing the payment related data.
+ */
+public class ConvenienceState {
+    /**
+     * Holds the last chosen import directories on a per-account basis. This data is for convenience only.
+     * We save a {@link String} instead of {@link Path} for portability reasons, as {@link Path}-Implementations are
+     * OS-dependent.
+     */
+    public Map<Account, String> importDirectories = new HashMap<>();
+
+    /**
+     * Similar to {@link #importDirectories}, but only holds the last state for whatever account, so we can use it
+     * as a fallback for new accounts / ones that haven't had any data imported.
+     */
+    public @Nullable String lastImportPath;
+
+    /**
+     * Init makes sure all fields have their initial value if they aren't set yet. While this will happen correctly
+     * on first creation of the database, adding fields will require this.
+     */
+    @SuppressWarnings("ConstantValue")
+    public void init() {
+        if (importDirectories == null) {
+            importDirectories = new HashMap<>();
+        }
+    }
+}

--- a/src/main/java/link/biosmarcel/baka/data/Data.java
+++ b/src/main/java/link/biosmarcel/baka/data/Data.java
@@ -1,6 +1,9 @@
 package link.biosmarcel.baka.data;
 
+import org.jspecify.annotations.Nullable;
+
 import java.math.BigDecimal;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -8,6 +11,8 @@ import java.util.*;
  * initialised once data is found. By default, such fields will be {@code null}.
  */
 public class Data {
+    public ConvenienceState convenienceState = new ConvenienceState();
+
     /**
      * A list of ALL payments. Sorted by {@link Payment#effectiveDate} descending.
      */
@@ -16,6 +21,27 @@ public class Data {
     public List<Account> accounts = new ArrayList<>();
 
     public List<ClassificationRule> classificationRules = new ArrayList<>();
+
+    /**
+     * Init makes sure all fields have their initial value if they aren't set yet. While this will happen correctly
+     * on first creation of the database, adding fields will require this.
+     */
+    @SuppressWarnings("ConstantValue")
+    public void init() {
+        if (convenienceState == null) {
+            convenienceState = new ConvenienceState();
+        }
+        convenienceState.init();
+        if (payments == null) {
+            payments = new ArrayList<>();
+        }
+        if (accounts == null) {
+            accounts = new ArrayList<>();
+        }
+        if (classificationRules == null) {
+            classificationRules = new ArrayList<>();
+        }
+    }
 
     /**
      * Import payments will add new payments to the data, if the data doesn't already exist.

--- a/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
+++ b/src/main/java/link/biosmarcel/baka/view/PaymentsView.java
@@ -30,6 +30,7 @@ import link.biosmarcel.baka.view.model.PaymentFX;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -180,10 +181,23 @@ public class PaymentsView extends BakaTab {
     }
 
     private void importHandler(final Account account, final BiFunction<Account, File, List<Payment>> importer) {
-        final var file = new FileChooser().showOpenDialog(getTabPane().getScene().getWindow());
+        final FileChooser fileChooser = new FileChooser();
+        final var initialDir = state.data.convenienceState.importDirectories.get(account);
+        if (initialDir != null) {
+            fileChooser.setInitialDirectory(new File(initialDir));
+        } else if (state.data.convenienceState.lastImportPath != null) {
+            fileChooser.setInitialDirectory(new File(state.data.convenienceState.lastImportPath));
+        }
+        final var file = fileChooser.showOpenDialog(getTabPane().getScene().getWindow());
         if (file == null) {
             return;
         }
+
+        state.data.convenienceState.lastImportPath = file.getParent();
+        state.storer.store(state.data.convenienceState);
+        state.data.convenienceState.importDirectories.put(account, file.getParent());
+        state.storer.store(state.data.convenienceState.importDirectories);
+        state.storer.commit();
 
         createPayments(importer.apply(account, file));
     }


### PR DESCRIPTION
This happens per account, as the data for one account might not be in the same location as the data for another account. Additionally we have a fallback to the last location, given that the account has never been used for imports.